### PR TITLE
fixes + improvements to tmp TMufasa procedures.

### DIFF
--- a/lib/tmp.simba
+++ b/lib/tmp.simba
@@ -94,14 +94,14 @@ begin
 end;
 
 (*
-TMufasaBitmap.createFromClient
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+TMufasaBitmap.copyFromClient
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: pascal
 
-    procedure TMufasaBitmap.createFromClient(const xs, ys, xe, ye: integer) overload;
+    procedure TMufasaBitmap.copyFromClient(const xs, ys, xe, ye: integer) overload;
 
-Creates a TMufasaBitmap from the CURRENT client.
+Copys and adds the area(xs, ys, xe, ye) from the current client to the TMufasaBitmap.
 
 - make around for TClient not being supported in lape currently.
 
@@ -113,23 +113,17 @@ Example:
 
 .. code-block:: pascal
 
-     tmb.createFromClient(100, 100, 500, 500);
+     tmb.copyFromClient(150, 150, 300, 300);
 
 *)
-procedure TMufasaBitmap.createFromClient(const xs, ys, xe, ye: integer) overload;
+procedure TMufasaBitmap.copyFromClient(const xs, ys, xe, ye: integer) overload;
 var
   tmp: integer;
-  tpa: TPointArray;
-  tia: TIntegerArray;
 begin
-  tmp := BitmapFromClient(xs, ys, xe, ye);
+  self.setSize(xs - xe, ys - ye);
 
-  tpa := TPAFromBox(intToBox(xs, ys, xe-1, ye-1));
-  tia := FastGetPixels(tmp, tpa);
-
-  self.init;
-  self.setSize(xe, ye);
-  self.setPixels(tpa, tia);
+  tmp := bitmapFromClient(xs, ys, xe, ye);
+  self := getMufasaBitmap(tmp).copy(0, 0, xe - xs, ye - ys);
 
   freeBitmap(tmp);
 end;
@@ -163,10 +157,15 @@ begin
     self.Rectangle(box, color)
   else
   begin
-    tpa := EdgeFromBox(box);
-    self.DrawTPA(tpa, color)
+    try
+      tpa := EdgeFromBox(box);
+    except
+      tpa := [point(box.x1, box.y1)];
+    finally
+      self.drawTPA(tpa, color)
+    end;
   end;
-end;
+end;  
 
 (*
 filterTPAsBetween


### PR DESCRIPTION
createFromClient > copyFromClient
- 10x shorter and functions correctly :)

Rectangle
- Fix (hacky) to stop a error if a box which is a single point is passed though to edgeFromBox.
