### PR TITLE
add-on's to various conversationbox func

### DIFF
--- a/lib/interfaces/conversationbox.simba
+++ b/lib/interfaces/conversationbox.simba
@@ -300,7 +300,7 @@ Example:
 
 .. code-block:: pascal
 
-    s := conversationBox.getOptions(onlyLength: boolean=false);
+    s := conversationBox.getOptions();
 *)
 function TRSConversationBox.getOptions(onlyLength: boolean=false): TStringArray;
 var


### PR DESCRIPTION
Summary:
1) added an additional paramater to .continue - it will just cause the function to return true if the continue button is present (and it won't click). Set to false by default so shouldn't cause compatibility issues. 
2) for .select(integer) - I changed it so it selected the number through typesend. also changed it up so that it gets the length of get options to determine if the related option is valid
3) added a parameter to .getoptions - onlyLength is set to false by default (no compatibility issues), but if set to true, such as the case in number 2 above, it won't waste time or resources searching for the tesseract text. it creates notable speed increases. So for .select(integer), you dont really care what the text is, you just want to know if your number is a valid one. 

Also for getOptions - i went ahead and added a check to see if the continue button was there - no reason to search for options if it is present 

All tested and everything. I preferred doing it this way as opposed to breaking it out into additional functions which would nearly be duplicates.
