### PR TITLE
Added ITEM_OUTLINE_BLACK_SECONDARY

### DIFF
--- a/lib/misc/items.simba
+++ b/lib/misc/items.simba
@@ -28,6 +28,7 @@ Example:
 *)
 const
   ITEM_OUTLINE_BLACK = 131072;
+  ITEM_OUTLINE_BLACK_SECONDARY = 65536;
   ITEM_OUTLINE_WHITE = 16777215;
   ITEM_TEXT_YELLOW   = 65535;
   ITEM_TEXT_WHITE = ITEM_OUTLINE_WHITE;
@@ -198,6 +199,7 @@ var
   p: TPoint;
 begin
   result := (findColor(p.x, p.y, ITEM_OUTLINE_BLACK, area) or
+             findColor(p.x, p.y, ITEM_OUTLINE_BLACK_SECONDARY, area) or
              findColor(p.x, p.y, ITEM_OUTLINE_WHITE, area));
 end;
 


### PR DESCRIPTION
-This should help item recognition for items/slots that do not have the
primary black outline color. 

The only function changed is isItemIn(box).
This function was the only one changed because this functions seems to
be a function meant for global use. However, other functions, such as
banking functions that check for item outline are meant for specific
purposes where an item outline of the primary black color should render
accurate results. If other files were to be changed, then isItemIn(box)
can be used.
