### PR TITLE
Update compass bounds to fix TRSminimap.getAngleRadians

### DIFF
--- a/lib/interfaces/minimap.simba
+++ b/lib/interfaces/minimap.simba
@@ -264,7 +264,7 @@ begin
     setBitmapName(bmpMask, 'Minimap Mask');
     setBounds([577, 12, 798, 200]);
                                           {bounds  center, radius}
-    button[MM_BUTTON_COMPASS]   := [[583, 19, 615, 51], [599, 35], 16];
+    button[MM_BUTTON_COMPASS]   := [[583, 19, 612, 48], [597, 33], 15];
     button[MM_BUTTON_RUN]       := [[759, 18, 793, 52], [776, 35], 16];
     button[MM_BUTTON_LODESTONE] := [[586, 161, 613, 188], [599, 174], 13];
     button[MM_BUTTON_MAP]       := [[764, 162, 788, 187], [776, 174], 12];


### PR DESCRIPTION
decreased image size by 3 pizels (w and h).
bounds used grab this: http://i.imgur.com/bGRJbj0.png (zoomed of course)
and now it grabs this: http://i.imgur.com/Itq8A14.png
