### PR TITLE
Added Withdraw-X to BoB and Prifddinas bank chest.

### DIFF
--- a/lib/interfaces/bankscreen.simba
+++ b/lib/interfaces/bankscreen.simba
@@ -1393,7 +1393,7 @@ TRSBankScreen.withdraw
 
 .. code-block:: pascal
 
-    function TRSBankScreen.withdraw(slot, amount: integer; var toFamiliar: boolean = false; mouseOverText: TStringArray): boolean;
+    function TRSBankScreen.withdraw(slot, amount: integer; mouseOverText: TStringArray; toFamiliar: boolean = false): boolean;
 
 Withdraws the the amount 'amount' from the bank slot 'slot', if the mouse-over
 text is correct, mouse-over text can also be skipped.  If toFamiliar is true, will


### PR DESCRIPTION
-Support for the new bankscreen withdrawal method "Withdraw-X to BoB" 
-Bankscreen.withdraw and overloaded functions now contain an optional boolean (default false) for withdrawing-x normally versus withdrawing-x to the beast of burden familiar.
-Added BANK_CHEST_PRIFDDINAS (supports both popular bank chests in the main Elf City)
-Edited range in line 2074 with new bank chest accordingly 
-Fixed typo "optn" -> "open"
-Added/updated corresponding comments/documentation

If no familiar is present when the Withdraw-X to BoB option is selected, the enter amount dialogue never appears, so __enterAmount times out normally.
