### PR TITLE
Added a maxTIme parameter to minimap.waitPlayerMoving()

### DIFF
--- a/lib/interfaces/minimap.simba
+++ b/lib/interfaces/minimap.simba
@@ -1236,7 +1236,7 @@ TRSMinimap.waitPlayerMoving
 
 .. code-block:: pascal
 
-    function TRSMinimap.waitPlayerMoving(waitFlagGone: boolean): boolean;
+    function TRSMinimap.waitPlayerMoving(shiftInterval: integer; maxTime: integer = 20000): boolean;
 
 Waits while the player is moving.  Returns true if the player is not moving.
 
@@ -1255,12 +1255,12 @@ Example:
       minimap.waitPlayerMoving();
     end;
 *)
-function TRSMinimap.waitPlayerMoving(shiftInterval: integer = 500): boolean;
+function TRSMinimap.waitPlayerMoving(shiftInterval: integer = 500; maxTime: integer = 20000): boolean;
 var
   t: LongWord;
 begin
   result := false;
-  t := (getSystemTime() + 20000);
+  t := (getSystemTime() + maxTime);
 
   print('Waiting while the player is moving...', TDebug.SUB);
 


### PR DESCRIPTION
The 20 second timeout is too long for some situations
