### PR TITLE
Bug in groupDigits (extended)

### DIFF
--- a/lib/utilities/math.simba
+++ b/lib/utilities/math.simba
@@ -152,7 +152,7 @@ numbers. Uses extended format instead of integer
 
 .. note::
 
-    - by PriSoner and Nava2
+    - by PriSoner, Nava2 and bonsai
 
 Example:
 
@@ -168,7 +168,11 @@ var
 begin
   result := toStr(n);
 
-  b := length(result) + 1;
+  b := pos('.', result);
+
+  if (b < 1) then
+    b := length(result) + 1;
+
   if (b > 3) then
   repeat
     b := b - 3;


### PR DESCRIPTION
Puts tokens in wrong places

Current output: 12,345,678,.98,222
Correct output: 12,345,678.98222

Fixed by bonsai as per: https://villavu.com/forum/issue.php?issueid=315
