### PR TITLE
Added minimap.enableRest()

### DIFF
--- a/lib/interfaces/minimap.simba
+++ b/lib/interfaces/minimap.simba
@@ -2877,6 +2877,44 @@ begin
 end;
 
 (*
+TRSMinimap.enableRest
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: pascal
+
+    function TRSMinimap.enableRest(): Boolean;
+
+Right clicks the run button and enables rest
+
+.. note::
+
+    - by The Mayor
+    - Last Updated: 07 December 2014 by The Mayor
+
+Example:
+
+.. code-block:: pascal
+
+    if minimap.enableRest() then
+      writeln('we are now resting');
+*)
+function TRSMinimap.enableRest(): Boolean;
+var
+  p: TPoint;
+begin
+  p := self.button[MM_BUTTON_RUN].center;
+
+  if (not self.isResting()) then
+  begin
+    mouseCircle(p.x, p.y, self.button[MM_BUTTON_RUN].radius, MOUSE_RIGHT);
+    result := chooseOption.select(['est']);
+  end else
+    result := true;
+
+  print('minimap.enableRest(): result = ' + boolToStr(result), TDebug.SUB);
+end;
+
+(*
 TRSMinimap.getRunEnergy
 ~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
I've also got minimap.getRunEnergy() which is accurate +/-4% when run/rest is enabled/disabled. Not sure if you want to add while clarity finishes the tesseract version.

``` pascal
function TRSMinimap.getRunEnergy(): Integer; override;
var
  count: Integer;
begin

  if getColor(point(self.button[MM_BUTTON_RUN].bounds.x1 + 29, self.button[MM_BUTTON_RUN].bounds.y1 + 21)) = 16777215 then
   result := 100
  else begin
    count := countColorTolerance(1126267, minimap.button[MM_BUTTON_RUN].bounds, 9, colorSetting(2, 0.20, 0.94));

    if self.isResting() then
      result := round((-0.0005 * pow(count, 2)) + (0.4792 * count) + 0.5272)
    else if self.isRunEnabled() then
      result := round((0.0002 * pow(count, 2)) + (0.298 * count) + 2.9935)
    else
      result := round((0.0001 * pow(count, 2)) + (0.2481 * count) + 1.3117)
  end;

  print('minimap.getRunEngery(): result = ' + toStr(result) + '%');
end;
```
