### PR TITLE
Added lodestoneScreen._isLocked()

### DIFF
--- a/lib/interfaces/lodestone.simba
+++ b/lib/interfaces/lodestone.simba
@@ -363,6 +363,8 @@ begin
   for i := 0 to high(DTMs) do
     if findDTM(DTMs[i], x, y, b) then
       result := true;
+      
+  freeDTMs(DTMs);
 
   if result then
     print('TRSLodestoneScreen._isLocked(): lodestone ' + toStr(location) + ' is not activated', TDebug.ERROR)


### PR DESCRIPTION
So you don't try and teleport to lodestones that are locked. Tested on openGL/directX and p2p/f2p
