### PR TITLE
Update grandexchange.simba

### DIFF
--- a/lib/interfaces/grandexchange.simba
+++ b/lib/interfaces/grandexchange.simba
@@ -378,7 +378,7 @@ begin
   timeOut := getTickCount64() + waitTime;
 
   while getTickCount64() < timeOut do
-    if (countColorTolerance(4501731, b, 72) > 100) then
+    if (countColorTolerance(4501731, b, 72) > 1800) then
       exit(true);
 end;
 

--- a/lib/interfaces/grandexchange.simba
+++ b/lib/interfaces/grandexchange.simba
@@ -361,7 +361,7 @@ Internal function which returns if the offer screen is open or not.
 .. note::
 
     - by The Mayor
-    - Last Updated: 14 January 2015 by The Mayor
+    - Last Updated: 27 April 2015 by BMWxi
 
 Example:
 


### PR DESCRIPTION
Fixed TRSGrandExchange._isOfferOpen by changing the required amount of yellow button colour from 100 to 1800. This is necessary because when the offer screen is not open there is ~1400 of the colour found because of the new 'COLLECT ALL TO INVENTORY' and 'COLLECT ALL TO BANK' buttons. There is ~2000 of the colour found when the offer screen is open.

Illustration: https://i.imgur.com/WLI0dPD.png