### PR TITLE
Update chooseoption.simba

### DIFF
--- a/lib/interfaces/chooseoption.simba
+++ b/lib/interfaces/chooseoption.simba
@@ -442,8 +442,8 @@ begin
 
     print('Options found: ' + toStr(s));
 
-    for i := 0 to high(optionArr) do
-      for j := 0 to high(txt) do
+    for j := 0 to high(txt) do
+      for i := 0 to high(optionArr) do
       begin
         if (matchPercent = 1.00) then // If we're not using stringmatch
           if (pos(txt[j], optionArr[i].str) > 0) then


### PR DESCRIPTION
Allows prioritising of the options in the array to search for. 
Example: ['Take Rune', 'Take Adamant'] will first search for 'Take Rune' in the options, instead of compairing option 1 to the strings of the search array..