### PR TITLE
Update targetinfo.simba

### DIFF
--- a/lib/interfaces/targetinfo.simba
+++ b/lib/interfaces/targetinfo.simba
@@ -173,11 +173,12 @@ __findLock
     function TRSTargetInfo.__findLock(): boolean;
 
 Internal function that returns true if the Target Info popup is detected and when it has a lock (differentiate it from mouse-over popup).
+Sadly, after a RS update this requires interfaces to be unlocked.
 
 .. note::
 
     - by Thomas
-    - Last Updated: 29 September 2015 by Thomas
+    - Last Updated: 25 February 2016 by Thomas
 
 
 Example:
@@ -191,15 +192,36 @@ Example:
 function TRSTargetInfo.__findLock(): boolean;
 var
   b, box: TBox;
+  i: Integer;
+  TPA: TPointArray;
+  ATPA: T2DPointArray;
+  color: TColorData := [2630170, 7, [2, [0.15, 1.36, 0.00]]];
 begin
-  if (not self.__find('slow')) then
+  color.gatherIn(TPA, mainScreen.getBounds());
+
+  if length(TPA) < 500 then
+  begin
+    print('TRSTargetInfo.__findLock(): Didn' 't find enough colors, target info isn' 't open.', TDebug.WARNING);
     exit();
+  end;
 
-  box := targetinfo.getBounds();
-  b := [box.x1, box.y1, box.x1 + 15, box.y2 -15];
+  ATPA := TPA.cluster(1);
+  ATPA.filterBetween(0, 400);
+  ATPA.sortBySize(true);
 
-  result := (countColorTolerance(2595536, b, 40) > 35);
-  print('TRSTargetInfo.__findLock(): ' + boolToStr(result));
+  if length(ATPA) then
+    for i := 0 to high(ATPA) do
+    begin
+      box := ATPA[i].getBounds();
+
+      if inRange(box.getHeight(), 28, 30) then
+      begin
+        b := [box.x1, box.y1, box.x1 + 15, box.y2 - 15];
+        if (countColorTolerance(2595536, b, 40) > 35) then
+          exit(true);
+      end;
+
+    end;
 end;
 {$ENDIF}  
 


### PR DESCRIPTION
Updated the _findlock procedure. Now less false negatives should pop-up.