### PR TITLE
GetSystemTime -> GetTickCount64

### DIFF
--- a/lib/utilities/time.simba
+++ b/lib/utilities/time.simba
@@ -289,10 +289,10 @@ Example:
 *)
 function waitFunc(Func: function: Boolean; WaitPerLoop, MaxTime: Integer): Boolean;
 var
-  T: LongWord;
+  T: UInt64;
 begin
-  T := GetSystemTime() + MaxTime;
-  while (GetSystemTime() < T) do
+  T := GetTickCount64() + MaxTime;
+  while (GetTickCount64() < T) do
   begin
     if (Func()) then
     begin
@@ -319,20 +319,20 @@ Notice the '@'.
 
 .. note::
 
-   by Olly
+    by Olly
 
 Example:
 
 .. code-block:: pascal
 
-     waitTypeFunc(@minimap.isResting, 50, 5000);
+    waitTypeFunc(@minimap.isResting, 50, 5000);
 *)
-function waitTypeFunc(Func: function: boolean of object; WaitPerLoop, MaxTime: Integer): Boolean;
+function waitTypeFunc(Func: function: Boolean of object; WaitPerLoop, MaxTime: Integer): Boolean;
 var
-  T: LongWord;
+  T: UInt64;
 begin
-  T := GetSystemTime() + MaxTime;
-  while (GetSystemTime() < T) do
+  T := GetTickCount64() + MaxTime;
+  while (GetTickCount64() < T) do
   begin
     if (Func()) then
     begin
@@ -354,7 +354,7 @@ TTimeMarker
         paused: Boolean;
     end;
 
-Timer type which is usefull for loops, timing and writing progress reports.
+Timer type which is useful for loops, timing and writing progress reports.
 
 .. note::
 
@@ -524,31 +524,32 @@ TCountDown
 .. code-block:: pascal
     
     type
-        tCountDown = uInt32;
+      TCountDown = type UInt64;
 
-Timer type which is usefull for loops, timing and writing progress reports.
+Timer type which is useful for loops, timing and writing progress reports.
 
 .. note::
 
     - by Obscurity
 *)
 type
-  TCountDown = uInt32;
+  TCountDown = type UInt64;
 
-function TCountDown.setTime(funcTime: uInt32): uInt32;
+function TCountDown.setTime(Time: UInt64): UInt64;
 begin
-  exit(self := getSystemTime() + funcTime);
+  self := GetTickCount64() + Time;
+  Result := self;
 end;
 
 function TCountDown.timeRemaining(): uInt32;
 begin
   if not self.isFinished() then
-    result := (self - getSystemTime());
+    Result := self - GetTickCount64();
 end;
 
-function TCountDown.isFinished(): boolean;
+function TCountDown.isFinished(): Boolean;
 begin
-  result := (getSystemTime() >= self);
+  result := GetTickCount64() >= self;
 end;
 
 {$f+}


### PR DESCRIPTION
... and then some minor formatting cleanups. 
I don't feel like merging this myself since I've had so little to do with SRL-6, best if someone else will do that. But I think this should be fine, and should hopefully not break any existing scripts, unless the scripter did something questionable:

The following _was_ possible
```pascal
var t:UInt32; //<--- yep
begin 
  t.setTime(1000);
  ...
end;
```
and that can no longer be done, as that's just.. bad :b