### PR TITLE
Changes to mouseScroll

### DIFF
--- a/lib/core/mouse.simba
+++ b/lib/core/mouse.simba
@@ -540,16 +540,25 @@ Example:
 *)
 procedure mouseScroll(pnt: TPoint; scrolls: integer; down: boolean = true);
 var
-  x, y, c: integer;
+  x, y, c, downInt, upInt: integer;
 begin
+  {$IFDEF LINUX}
+    downInt := 1; upInt := -1;
+  {$ELSE}
+  {$IFDEF SMART}
+    downInt := 1; upInt := -1;
+  {$ELSE}
+    downInt := -1; upInt := 1;
+  {$ENDIF}
+  {$ENDIF}
   mouse(pnt, MOUSE_MOVE);
   getMousePos(x, y);
 
   repeat
     if down then
-      scrollMouse(x, y, 1)
+      scrollMouse(x, y, downInt)
     else
-      scrollMouse(x, y, -1);
+      scrollMouse(x, y, upInt);
 
     wait(16 + random(200));
     inc(c);


### PR DESCRIPTION
Up and down on ScrollMouse are inverted on windows when not using SMART
so mouseScroll does not work correctly. Code taken from
https://github.com/SRL/SRL/blob/master/shared/mouse.simba#L541
acow/no lifer had this issue https://villavu.com/forum/showthread.php?t=116111 and I just gave him an overload to fix it but this will fix it for everyone.