### PR TITLE
Update time.simba

### DIFF
--- a/lib/utilities/time.simba
+++ b/lib/utilities/time.simba
@@ -269,17 +269,18 @@ waitFunc
 
 .. code-block:: pascal
 
-    function waitFunc(Func: Function: Boolean; WaitPerLoop, MaxTime: Integer): Boolean;
+    function waitFunc(Func: Function: Boolean; WaitPerLoop, MaxTime: Integer; Value: Boolean = true): Boolean;
 
-Waits for function Func to be true. WaitPerLoop is how often you
+Waits for function Func to be true or false (default true). WaitPerLoop is how often you
 want to call "Func" function.
-Example: "WaitFunc(@BankScreen, 10 + Random(15), 750);" will check if BankScreen
+Example: "waitFunc(@BankScreen, 10 + Random(15), 750);" will check if BankScreen
 is open every 10-25th millisecond, for a maximum of 750 milliseconds.
 Notice the '@'.
 
 .. note::
 
-  by Rasta Magician, small edit by EvilChicken!
+    - by Rasta Magician, small edit by EvilChicken!
+    - Last Updated: 17 July 2016 by BMWxi
 
 Example:
 
@@ -287,19 +288,18 @@ Example:
 
      waitFunc(@funcName, 50, 5000);
 *)
-function waitFunc(Func: function: Boolean; WaitPerLoop, MaxTime: Integer): Boolean;
+function waitFunc(Func: function: Boolean; WaitPerLoop, MaxTime: Integer; Value: Boolean = True): Boolean;
 var
   T: UInt64;
 begin
   T := GetTickCount64() + MaxTime;
   while (GetTickCount64() < T) do
   begin
-    if (Func()) then
+    if (Func() = value) then
     begin
-      Result := True;
-      Exit;
+      exit(True);
     end;
-    Wait(WaitPerLoop);
+    wait(WaitPerLoop);
   end;
 end;
 
@@ -309,17 +309,18 @@ waitTypeFunc
 
 .. code-block:: pascal
 
-    function waitTypeFunc(Func: function: boolean of object; WaitPerLoop, MaxTime: Integer): Boolean;
+    function waitTypeFunc(Func: function: boolean of object; WaitPerLoop, MaxTime: Integer; Value: Boolean = True): Boolean;
 
-Waits for a type function Func to be true. WaitPerLoop is how often you
+Waits for a type function Func to be true or false (default true). WaitPerLoop is how often you
 want to call "Func" function.
-Example: "WaitFunc(@BankScreen, 10 + Random(15), 750);" will check if BankScreen
+Example: "waitTypeFunc(@bankScreen.isOpen, 10 + Random(15), 750);" will check if bankScreen
 is open every 10-25th millisecond, for a maximum of 750 milliseconds.
 Notice the '@'.
 
 .. note::
 
-    by Olly
+    - by Olly
+    - Last Updated: 17 July 2016 by BMWxi
 
 Example:
 
@@ -327,19 +328,18 @@ Example:
 
     waitTypeFunc(@minimap.isResting, 50, 5000);
 *)
-function waitTypeFunc(Func: function: Boolean of object; WaitPerLoop, MaxTime: Integer): Boolean;
+function waitTypeFunc(Func: function: Boolean of object; WaitPerLoop, MaxTime: Integer; Value: Boolean = True): Boolean;
 var
   T: UInt64;
 begin
   T := GetTickCount64() + MaxTime;
   while (GetTickCount64() < T) do
   begin
-    if (Func()) then
+    if (Func() = Value) then
     begin
-      Result := True;
-      Exit;
+      exit(True);
     end;
-    Wait(WaitPerLoop);
+    wait(WaitPerLoop);
   end;
 end;
 


### PR DESCRIPTION
Added an optional boolean parameter 'Value' to waitFunc and waitTypeFunc, so that they will wait for the function to match the Value instead of just waiting for the function to be true. This allows things such as `waitTypeFunc(@bankScreen.isOpen, 50, 2000, false);` which waits for the bankScreen to be closed.

This does not break backwards compatibility; The extra parameter is optional, and defaults to true so the function will behave the same for existing implementations.