### PR TITLE
Update lobby.simba

### DIFF
--- a/lib/interfaces/lobby/lobby.simba
+++ b/lib/interfaces/lobby/lobby.simba
@@ -267,7 +267,7 @@ Example:
 *)
 function TRSLobby.getCurrentTab(): Integer;
 const
-  INACTIVE_TAB_BOTTOM = 9078134; // Bottom line of inactive tab
+  INACTIVE_TAB_BOTTOM = 9209461; // Bottom line of inactive tab
 begin
   result := -1;
 


### PR DESCRIPTION
Small bug causing lobby methods to fail. Might also add a method that clicks away from their new text screen forcing NXT upon players that causes waitClientReady() (used by SetupSRL) to fail.