### PR TITLE
Creates a .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.simba linguist-language=Pascal


### PR DESCRIPTION
& uses a linguist override to define .simba files as pascal. End result will be that github recognises srl/srl6 as a pascal project.